### PR TITLE
Propagate endpoint ID into endpointslice names

### DIFF
--- a/sync/chart/templates/endpointslice.yaml
+++ b/sync/chart/templates/endpointslice.yaml
@@ -3,13 +3,7 @@
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
-  # Generate a suffix based on the address and port for the slice
-  name: {{
-    printf "%s:%s" .address .port |
-      sha256sum |
-      substr 0 5 |
-      printf "%s-%s" $.Release.Name
-  }}
+  name: {{ printf "%s-%s" $.Release.Name .id }}
   labels:
     {{- include "zenith-service.labels" $ | nindent 4 }}
     kubernetes.io/service-name: {{ $.Release.Name }}

--- a/sync/chart/values.yaml
+++ b/sync/chart/values.yaml
@@ -12,7 +12,8 @@ global:
 
 # The endpoints for the service
 endpoints: []
-  # - address: 10.0.0.1
+  # - id: abcde
+  #   address: 10.0.0.1
   #   port: 31234
 
 # The protocol for the service

--- a/sync/zenith/sync/model.py
+++ b/sync/zenith/sync/model.py
@@ -8,6 +8,8 @@ class Endpoint:
     """
     Represents an endpoint for a service.
     """
+    #: The ID of the endpoint
+    id: str
     #: The address for the endpoint
     address: str
     #: The port for the endpoint

--- a/sync/zenith/sync/store/crd/store.py
+++ b/sync/zenith/sync/store/crd/store.py
@@ -107,8 +107,8 @@ class Store(base.Store):
         return model.Service(
             name = endpoints.metadata.name,
             endpoints = [
-                model.Endpoint(address = ep.address, port = ep.port)
-                for ep in endpoints.spec.endpoints.values()
+                model.Endpoint(id = id, address = ep.address, port = ep.port)
+                for id, ep in endpoints.spec.endpoints.items()
                 if ep.status != api.EndpointStatus.CRITICAL
             ],
             # Merge the configs associated with each endpoint


### PR DESCRIPTION
This makes the Zenith `lease` and the corresponding `endpointslice` have the same name, aiding debugging.