### PR TITLE
Fix read timeout being interpreted as exponential

### DIFF
--- a/sync/chart/templates/_helpers.tpl
+++ b/sync/chart/templates/_helpers.tpl
@@ -32,7 +32,7 @@ Annotations for the ingress resource.
 {{ toYaml .Values.ingress.annotations }}
 nginx.ingress.kubernetes.io/backend-protocol: {{ quote .Values.protocol }}
 {{- with .Values.readTimeout }}
-nginx.ingress.kubernetes.io/proxy-read-timeout: {{ quote . }}
+nginx.ingress.kubernetes.io/proxy-read-timeout: {{ int64 . | quote }}
 {{- end }}
 {{- if .Values.global.secure }}
 {{- include "zenith-service.ingress.tls.annotations" . }}


### PR DESCRIPTION
Currently Helm templating interprets large numbers as exponential floats, resulting in the read timeout annotation on ingress resources being interpreted as 
`nginx.ingress.kubernetes.io/proxy-read-timeout: "3.1536e+07"`
which is no longer allowed by the current version of the nginx ingress controller