### PR TITLE
.grype.yaml: Update ignore list for Go vulnerabilities absent from up…

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -3,4 +3,14 @@ ignore:
   - vulnerability: GHSA-p77j-4mvh-x3m3
     package:
       location: "/usr/bin/helm"
-
+  # Running govulncheck on the upstream code https://github.com/hairyhenderson/gomplate/tree/v5.1.0
+  # shows no vulnerabilities as affected symbols are absent
+  - vulnerability: GO-2026-5020
+  - vulnerability: GO-2026-5026
+  - vulnerability: GO-2026-5023
+  - vulnerability: GO-2026-5006
+  - vulnerability: GO-2026-5021
+  - vulnerability: GO-2026-5006
+  - vulnerability: GO-2026-5017
+  - vulnerability: GO-2026-5019
+  - vulnerability: GO-2026-5005


### PR DESCRIPTION
…stream code

The zenith images use `hairyhenderson/gomplate` as an upstream image to build from. This uses a version of Go with vulnerabilities in. Running `govulncheck` on the upstream code base shows no vulnerable symbols are used.