### PR TITLE
sync/Dockerfile: Bump helm version to the latest 3.X available

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOMPLATE_VERSION=v5.1.0
+ARG GOMPLATE_VERSION=v5.2.0
 
 
 # Use a named build stage for gomplate

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 # Install yq from the official Docker image
 COPY --from=mikefarah/yq /usr/bin/yq /usr/bin/
 
-ARG HELM_VERSION=v3.20.2
+ARG HELM_VERSION=v3.21.3
 RUN set -ex; \
     OS_ARCH="$(uname -m)"; \
     case "$OS_ARCH" in \


### PR DESCRIPTION
This will hopefully allow the GO vulnerabilities checks to pass